### PR TITLE
Added a missing dependency

### DIFF
--- a/rjs_require_config.js
+++ b/rjs_require_config.js
@@ -94,7 +94,7 @@ var requirejs = {
         },
 
         styleCollection: {
-            deps:['readiumSDK'],
+            deps:['readiumSDK', 'style'],
             exports: 'styleCollection'
         },
 


### PR DESCRIPTION
ReadiumSDK.Models.Style was undefined when trying to make an API call. This fixes the problem.
