### PR TITLE
Fix missing markup parser definition.

### DIFF
--- a/epub-modules/epub-fetch/src/models/resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/resource_fetcher.js
@@ -13,6 +13,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './discover_c
             'application/zip': 'zipped'
         };
 
+        var _markupParser = new MarkupParser();
         var _isExploded;
         var _dataFetcher;
         


### PR DESCRIPTION
Hi!

This brings back the accidentally deleted field definition. 
