### PR TITLE
Correctly check if rootUrl ends with ".epub"

### DIFF
--- a/epub-modules/epub-fetch/src/models/resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/resource_fetcher.js
@@ -38,7 +38,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './discover_c
         function isExploded() {
 
             var ext = ".epub";
-            return rootUrl.indexOf(ext, this.length - ext.length) === -1;
+            return rootUrl.indexOf(ext, rootUrl.length - ext.length) === -1;
         }
 
         function createDataFetcher(isExploded, callback) {


### PR DESCRIPTION
isExploded wants to check if the rootUrl ends in ".epub". Currently the code checks the length of "this" (which is the DOMWindow object). The code should be checking the length of rootUrl instead.
