### PR TITLE
Fix a bug with CSS url() replacement

### DIFF
--- a/epub-modules/epub-fetch/src/models/resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/resource_fetcher.js
@@ -233,9 +233,12 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './discover_c
                         } else {
                             processedUrlString = "url('" + processedResourceDescriptor.resourceObjectURL + "')";
                         }
+                        var origMatchedUrlStringEscaped = origMatchedUrlString.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+                        var origMatchedUrlStringRegExp = new RegExp(origMatchedUrlStringEscaped, 'g');
                         //noinspection JSCheckFunctionSignatures
                         styleSheetResourceData =
-                            styleSheetResourceData.replace(origMatchedUrlString, processedUrlString, 'g');
+                            styleSheetResourceData.replace(origMatchedUrlStringRegExp, processedUrlString, 'g');
+
                     }
                     callback(styleSheetResourceData);
                 });


### PR DESCRIPTION
This fixes a bug where only the first occurence of a given url() reference was being replaced when preprocessing style sheet text.
