### PR TITLE
Fix Firefox XML namespace handling incompatibilities in package document parser

### DIFF
--- a/epub-modules/epub/src/models/package_document_parser.js
+++ b/epub-modules/epub/src/models/package_document_parser.js
@@ -167,28 +167,43 @@ define(['require', 'module', 'jquery', 'underscore', 'backbone', 'epub-fetch/mar
             return jsonSpine;
         }
 
+        function findXmlElemByLocalNameAnyNS(rootElement, localName) {
+            return rootElement.getElementsByTagNameNS("*", localName)[0];
+        }
+
+        function getElemText(rootElement, localName) {
+            var foundElement = findXmlElemByLocalNameAnyNS(rootElement, localName);
+            if (foundElement) {
+                return foundElement.textContent;
+            } else {
+                return '';
+            }
+        }
+
         function getJsonMetadata(xmlDom) {
 
             var $metadata = $("metadata", xmlDom);
+            var metadataElem = xmlDom.getElementsByTagNameNS("*", "metadata")[0];
             var jsonMetadata = {};
 
-            jsonMetadata.author = $("creator", $metadata).text();
-            jsonMetadata.description = $("description", $metadata).text();
+            jsonMetadata.author = getElemText(metadataElem, "creator");
+            jsonMetadata.description = getElemText(metadataElem, "description");
+            // TODO: Convert all jQuery queries (that get confused by XML namespaces on Firefox) to getElementsByTagNameNS().
             jsonMetadata.epub_version =
                 $("package", xmlDom).attr("version") ? $("package", xmlDom).attr("version") : "";
-            jsonMetadata.id = $("identifier", $metadata).text();
-            jsonMetadata.language = $("language", $metadata).text();
+            jsonMetadata.id = getElemText(metadataElem,"identifier");
+            jsonMetadata.language = getElemText(metadataElem, "language");
             jsonMetadata.layout = $("meta[property='rendition:layout']", $metadata).text();
             jsonMetadata.modified_date = $("meta[property='dcterms:modified']", $metadata).text();
             jsonMetadata.ncx = $("spine", xmlDom).attr("toc") ? $("spine", xmlDom).attr("toc") : "";
             jsonMetadata.orientation = $("meta[property='rendition:orientation']", $metadata).text();
             jsonMetadata.page_prog_dir = $("spine", xmlDom).attr("page-progression-direction") ?
                 $("spine", xmlDom).attr("page-progression-direction") : "";
-            jsonMetadata.pubdate = $("date", $metadata).text();
-            jsonMetadata.publisher = $("publisher", $metadata).text();
-            jsonMetadata.rights = $("rights").text();
+            jsonMetadata.pubdate = getElemText(metadataElem, "date");
+            jsonMetadata.publisher = getElemText(metadataElem, "publisher");
+            jsonMetadata.rights = getElemText(metadataElem, "rights");
             jsonMetadata.spread = $("meta[property='rendition:spread']", $metadata).text();
-            jsonMetadata.title = $("title", $metadata).text();
+            jsonMetadata.title = getElemText(metadataElem, "title");
             
             
             // Media part


### PR DESCRIPTION
Hi!

When working on the readium-js data model, I've discovered a bug on non-WebKit browsers. On WebKit, jQuery selectors against XML DOM work without regard for XML namespaces. On the other hand, other engines do the opposite - they won't match an element if in the original document it's physically prefixed with a namespace prefix. In such a case, they require matching against the full element name (prefix:localName), which is not portable (the used prefix can change from document to document).

My partial fix (more complex jQuery selectors still need conversion, as noted in the TODO comment) is to use the getElementsByTagNameNS() function, with a "*" namespace wildcard, based on information from this article: http://wiki.orbeon.com/forms/doc/contributor-guide/browser#TOC-Get-elements-with-prefixes. 

This approach should also work for IE9 and IE10 (but not for IE <= 8).
