### PR TITLE
Add missing "var" keyword to avoid implicit global variable usage.

### DIFF
--- a/epub-modules/epub/src/models/package_document_parser.js
+++ b/epub-modules/epub/src/models/package_document_parser.js
@@ -29,7 +29,7 @@ define(['require', 'module', 'jquery', 'underscore', 'backbone', 'epub-fetch/mar
             } else {
                 // parse as hh:mm:ss.fraction
                 // this also works for seconds-only, e.g. 12.345
-                arr = value.split(":");
+                var arr = value.split(":");
                 secs = parseFloat(arr.pop());
                 if (arr.length > 0) {
                     mins = parseFloat(arr.pop());


### PR DESCRIPTION
Fix for a small, accidentally discovered global variable leakage bug.
