### PR TITLE
Fix a bug with iBooks display options fetching.

### DIFF
--- a/epub-modules/epub-fetch/src/models/publication_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/publication_fetcher.js
@@ -183,6 +183,10 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             }
 
             var pathRelativeToZipRoot = decodeURIComponent(self.convertPathRelativeToPackageToRelativeToBase(relativeToPackagePath));
+            // In case we received an absolute path, convert it to relative form or the fetch will fail:
+            if (pathRelativeToZipRoot.charAt(0) === '/') {
+                pathRelativeToZipRoot = pathRelativeToZipRoot.substr(1);
+            }
             var fetchFunction = _resourceFetcher.fetchFileContentsText;
             if (fetchMode === 'blob') {
                 fetchFunction = _resourceFetcher.fetchFileContentsBlob;

--- a/epub-modules/epub/src/models/package_document_parser.js
+++ b/epub-modules/epub/src/models/package_document_parser.js
@@ -97,7 +97,7 @@ define(['require', 'module', 'jquery', 'underscore', 'backbone', 'epub-fetch/mar
             //if layout not set
             if(!metadata.layout)
             {
-                var pathToIBooksSpecificXml = new URI("/META-INF/com.apple.ibooks.display-options.xml");
+                var pathToIBooksSpecificXml = "/META-INF/com.apple.ibooks.display-options.xml";
 
                 publicationFetcher.relativeToPackageFetchFileContents(pathToIBooksSpecificXml, 'text', function (ibookPropText) {
                     if(ibookPropText) {


### PR DESCRIPTION
The options XML document fetching has been always failing due to invalid use of absolute file path.
