### PR TITLE
Support audio and video tags in epub-fetch

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -45,6 +45,8 @@ define(
                 var resolutionDeferreds = [];
 
                 resolveDocumentImages(resolutionDeferreds, onerror);
+                resolveDocumentAudios(resolutionDeferreds, onerror);
+                resolveDocumentVideos(resolutionDeferreds, onerror);
                 resolveDocumentLinkStylesheets(resolutionDeferreds, onerror);
                 resolveDocumentEmbeddedStylesheets(resolutionDeferreds, onerror);
 
@@ -261,6 +263,14 @@ define(
 
             function resolveDocumentImages(resolutionDeferreds, onerror) {
                 resolveResourceElements('img', 'src', 'blob', resolutionDeferreds, onerror);
+            }
+
+            function resolveDocumentAudios(resolutionDeferreds, onerror) {
+                resolveResourceElements('audio', 'src', 'blob', resolutionDeferreds, onerror);
+            }
+
+            function resolveDocumentVideos(resolutionDeferreds, onerror) {
+                resolveResourceElements('video', 'src', 'blob', resolutionDeferreds, onerror);
             }
 
             function resolveDocumentLinkStylesheets(resolutionDeferreds, onerror) {


### PR DESCRIPTION
Currently, this is implemented in a naive way - by fetching media
resources into memory in their entirety as blobs.

This has a downside of consuming lots of browser heap space.

However, if the resource is fetched from a remote ZIP file, streaming is
impossible due to absence of random access.

In the future, we might fetch media files to local filesystem using the experimental HTML5
temporary filesystem API and stream from over there.
