### PR TITLE
Stop fetching media assets programmatically if the EPUB is exploded.

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -16,7 +16,7 @@ define(
     function (require, module, $, URI, ContentTypeDiscovery) {
 
 
-        var ContentDocumentFetcher = function (publicationFetcher, spineItem, publicationResourcesCache) {
+        var ContentDocumentFetcher = function (publicationFetcher, spineItem, loadedDocumentUri, publicationResourcesCache) {
 
             var self = this;
 
@@ -41,12 +41,15 @@ define(
             this.resolveInternalPackageResources = function (resolvedDocumentCallback, onerror) {
 
                 _contentDocumentDom = _publicationFetcher.markupParser.parseMarkup(_contentDocumentText, _srcMediaType);
+                setBaseUri(_contentDocumentDom, loadedDocumentUri);
 
                 var resolutionDeferreds = [];
 
-                resolveDocumentImages(resolutionDeferreds, onerror);
-                resolveDocumentAudios(resolutionDeferreds, onerror);
-                resolveDocumentVideos(resolutionDeferreds, onerror);
+                if (_publicationFetcher.shouldFetchMediaAssetsProgrammatically()) {
+                    resolveDocumentImages(resolutionDeferreds, onerror);
+                    resolveDocumentAudios(resolutionDeferreds, onerror);
+                    resolveDocumentVideos(resolutionDeferreds, onerror);
+                }
                 resolveDocumentLinkStylesheets(resolutionDeferreds, onerror);
                 resolveDocumentEmbeddedStylesheets(resolutionDeferreds, onerror);
 
@@ -57,6 +60,15 @@ define(
             };
 
             // INTERNAL FUNCTIONS
+
+            function setBaseUri(documentDom, baseURI) {
+                var baseElem = documentDom.getElementsByTagName('base')[0];
+                if (!baseElem) {
+                    baseElem = documentDom.createElement('base');
+                    documentDom.getElementsByTagName('body')[0].appendChild(baseElem);
+                }
+                baseElem.setAttribute('href', baseURI);
+            }
 
             function _handleError(err) {
                 if (err) {
@@ -271,6 +283,7 @@ define(
 
             function resolveDocumentVideos(resolutionDeferreds, onerror) {
                 resolveResourceElements('video', 'src', 'blob', resolutionDeferreds, onerror);
+                resolveResourceElements('video', 'poster', 'blob', resolutionDeferreds, onerror);
             }
 
             function resolveDocumentLinkStylesheets(resolutionDeferreds, onerror) {

--- a/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
+++ b/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
@@ -11,7 +11,7 @@
 //  used to endorse or promote products derived from this software without specific 
 //  prior written permission.
 
-define([], function(){
+define(['URIjs'], function(URI){
 
     var zipIframeLoader = function(ReadiumSDK, getCurrentResourceFetcher) {
 
@@ -23,10 +23,12 @@ define([], function(){
 
         this.loadIframe = function(iframe, src, callback, caller, attachedData) {
 
-            var shouldFetchProgrammatically = getCurrentResourceFetcher().shouldFetchProgrammatically();
-            if (shouldFetchProgrammatically) {
+            var loadedDocumentUri = new URI(src).absoluteTo(iframe.baseURI).search('').hash('').toString();
+
+            var shouldConstructDomProgrammatically = getCurrentResourceFetcher().shouldConstructDomProgrammatically();
+            if (shouldConstructDomProgrammatically) {
                 var basicLoadCallback = function (success) {
-                    getCurrentResourceFetcher().fetchContentDocument(attachedData,
+                    getCurrentResourceFetcher().fetchContentDocument(attachedData, loadedDocumentUri,
                         function (resolvedContentDocumentDom) {
                             var contentDocument = iframe.contentDocument;
                             contentDocument.replaceChild(resolvedContentDocumentDom.documentElement,

--- a/epub-modules/epub-fetch/src/models/publication_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/publication_fetcher.js
@@ -26,7 +26,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             'application/zip': 'zipped'
         };
 
-        var _shouldFetchProgrammatically;
+        var _shouldConstructDomProgrammatically;
         var _resourceFetcher;
         var _encryptionHandler;
         var _packageFullPath;
@@ -42,7 +42,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             var isEpubExploded = isExploded();
 
             // Non exploded EPUBs (i.e. zipped .epub documents) should be fetched in a programmatical manner:
-            _shouldFetchProgrammatically = !isEpubExploded;
+            _shouldConstructDomProgrammatically = !isEpubExploded;
             createResourceFetcher(isEpubExploded, callback);
         };
 
@@ -94,8 +94,21 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
          *
          * false if documents can be fed directly into a window or iframe by src URL without using special fetching logic.
          */
-        this.shouldFetchProgrammatically = function (){
-            return _shouldFetchProgrammatically;
+        this.shouldConstructDomProgrammatically = function (){
+            return _shouldConstructDomProgrammatically;
+        };
+
+        /**
+         * Determine whether the media assets (audio, video, images) within content documents require special
+         * programmatic handling.
+         * @returns {*} true if content documents fetched using this fetcher require programmatic fetching
+         * of media assets. Typically needed for zipped EPUBs.
+         *
+         * false if paths to media assets are accessible directly for the browser through their paths relative to
+         * the base URI of their content document.
+         */
+        this.shouldFetchMediaAssetsProgrammatically = function() {
+            return _shouldConstructDomProgrammatically && !isExploded();
         };
 
         this.getBookRoot = function() {
@@ -110,9 +123,9 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             return _resourceFetcher.getPackageUrl();
         };
 
-        this.fetchContentDocument = function (attachedData, contentDocumentResolvedCallback, errorCallback) {
+        this.fetchContentDocument = function (attachedData, loadedDocumentUri, contentDocumentResolvedCallback, errorCallback) {
 
-            var contentDocumentFetcher = new ContentDocumentFetcher(self, attachedData.spineItem, _publicationResourcesCache);
+            var contentDocumentFetcher = new ContentDocumentFetcher(self, attachedData.spineItem, loadedDocumentUri, _publicationResourcesCache);
             contentDocumentFetcher.fetchContentDocumentAndResolveDom(contentDocumentResolvedCallback, function (err) {
                 _handleError(err);
                 errorCallback(err);
@@ -182,10 +195,10 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
                 onerror = _handleError;
             }
 
-            var pathRelativeToZipRoot = decodeURIComponent(self.convertPathRelativeToPackageToRelativeToBase(relativeToPackagePath));
+            var pathRelativeToEpubRoot = decodeURIComponent(self.convertPathRelativeToPackageToRelativeToBase(relativeToPackagePath));
             // In case we received an absolute path, convert it to relative form or the fetch will fail:
-            if (pathRelativeToZipRoot.charAt(0) === '/') {
-                pathRelativeToZipRoot = pathRelativeToZipRoot.substr(1);
+            if (pathRelativeToEpubRoot.charAt(0) === '/') {
+                pathRelativeToEpubRoot = pathRelativeToEpubRoot.substr(1);
             }
             var fetchFunction = _resourceFetcher.fetchFileContentsText;
             if (fetchMode === 'blob') {
@@ -193,7 +206,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             } else if (fetchMode === 'data64uri') {
                 fetchFunction = _resourceFetcher.fetchFileContentsData64Uri;
             }
-            fetchFunction.call(_resourceFetcher, pathRelativeToZipRoot, fetchCallback, onerror);
+            fetchFunction.call(_resourceFetcher, pathRelativeToEpubRoot, fetchCallback, onerror);
         };
 
 
@@ -210,7 +223,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
             _encryptionHandler.initializeEncryptionHash(function() {
                 if (_encryptionHandler.isEncryptionSpecified()) {
                     // EPUBs that use encryption for any resources should be fetched in a programmatical manner:
-                    _shouldFetchProgrammatically = true;
+                    _shouldConstructDomProgrammatically = true;
                 }
                 settingFinishedCallback();
             });


### PR DESCRIPTION
This commit introduces an exception to programmatic fetching for media
assets when dealing with exploded EPUBs.

Programmatic fetching can be currently triggered for exploded EPUBs if
they declare obfuscated fonts in META-INF/encryption.xml.

Since such encryption cannot currently apply to media assets (videos,
audio files, images), it makes no sense to programmatically fetch those.

For this reason, in such a case references to those assets are left
untouched, they aren't fetched programmatically and the base URI of the
programmatically constructed content document is configured so that
those media asset references are resolved correctly by the browser.
