### PR TITLE
Fetch SCRIPT, IFRAME srcs when fetching programmatically.

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -50,6 +50,11 @@ define(
                     resolveDocumentAudios(resolutionDeferreds, onerror);
                     resolveDocumentVideos(resolutionDeferreds, onerror);
                 }
+                // TODO: recursive fetching, parsing and DOM construction of documents in IFRAMEs,
+                // with CSS preprocessing and obfuscated font handling
+                resolveDocumentIframes(resolutionDeferreds, onerror);
+                // TODO: resolution (e.g. using DOM mutation events) of scripts loaded dynamically by scripts
+                resolveDocumentScripts(resolutionDeferreds, onerror);
                 resolveDocumentLinkStylesheets(resolutionDeferreds, onerror);
                 resolveDocumentEmbeddedStylesheets(resolutionDeferreds, onerror);
 
@@ -288,6 +293,14 @@ define(
             function resolveDocumentVideos(resolutionDeferreds, onerror) {
                 resolveResourceElements('video', 'src', 'blob', resolutionDeferreds, onerror);
                 resolveResourceElements('video', 'poster', 'blob', resolutionDeferreds, onerror);
+            }
+
+            function resolveDocumentScripts(resolutionDeferreds, onerror) {
+                resolveResourceElements('script', 'src', 'blob', resolutionDeferreds, onerror);
+            }
+
+            function resolveDocumentIframes(resolutionDeferreds, onerror) {
+                resolveResourceElements('iframe', 'src', 'blob', resolutionDeferreds, onerror);
             }
 
             function resolveDocumentLinkStylesheets(resolutionDeferreds, onerror) {


### PR DESCRIPTION
When programmatic fetching of the content document is in place, any
relative SCRIPT and IFRAME src references should also be fetched,
otherwise they will not be correctly loaded by the browser (in case of
zipped EPUBs) or (in case of exploded EPUBs with obfuscated fonts) will
not be able to be preprocessed (a requirement for any future
implementation of recursive processing of documents contained in IFRAMEs
and their stylesheets, needed for handling of obfuscated fonts).
