### PR TITLE
Issue 54 IE fixes - construct the DOM using document.write.

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -59,6 +59,8 @@ define(
                 resolveDocumentEmbeddedStylesheets(resolutionDeferreds, onerror);
 
                 $.when.apply($, resolutionDeferreds).done(function () {
+                    // console.log('Publication resources cache contents after resolving resources:');
+                    // _publicationResourcesCache.consoleDump();
                     resolvedDocumentCallback(_contentDocumentDom);
                 });
 
@@ -127,7 +129,7 @@ define(
                                 //noinspection JSUnresolvedVariable,JSUnresolvedFunction
                                 var resourceObjectURL = window.URL.createObjectURL(finalResourceData);
                                 _publicationResourcesCache.putResourceURL(resourceUriRelativeToPackageDocument,
-                                    resourceObjectURL);
+                                    resourceObjectURL, finalResourceData);
                                 // TODO: take care of releasing object URLs when no longer needed
                                 replaceRefAttrInElem(resourceObjectURL);
                                 resolutionDeferred.resolve();
@@ -178,7 +180,8 @@ define(
                             isStyleSheetResource: isStyleSheetResource,
                             resourceObjectURL: resourceObjectURL
                         };
-                        _publicationResourcesCache.putResourceURL(resourceUriRelativeToPackageDocument, resourceObjectURL);
+                        _publicationResourcesCache.putResourceURL(resourceUriRelativeToPackageDocument,
+                            resourceObjectURL, resourceDataBlob);
                         cssUrlFetchDeferred.resolve();
                     };
                     var fetchErrorCallback = function (error) {

--- a/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
+++ b/epub-modules/epub-fetch/src/models/iframe_zip_loader.js
@@ -15,6 +15,12 @@ define(['URIjs'], function(URI){
 
     var zipIframeLoader = function(ReadiumSDK, getCurrentResourceFetcher) {
 
+        var emptyDocumentBlob = new Blob(['<html><body></body></html>'], {'type': 'text/html'});
+
+        // Internet Explorer workaround - need to hold on to Blobs so that they aren't GC'd and their object URLs invalidated:
+        // Must hold the blob in a hash so that IE doesn't optimize out the unused variable and GC the blob:
+        var holderHash = {emptyDocumentBlob: emptyDocumentBlob};
+
         var basicIframeLoader = new ReadiumSDK.Views.IFrameLoader();
 
         this.addIFrameEventListener = function(eventName, callback, context) {
@@ -27,26 +33,39 @@ define(['URIjs'], function(URI){
 
             var shouldConstructDomProgrammatically = getCurrentResourceFetcher().shouldConstructDomProgrammatically();
             if (shouldConstructDomProgrammatically) {
+                console.log('loading [' + loadedDocumentUri + ']');
+
                 var basicLoadCallback = function (success) {
                     getCurrentResourceFetcher().fetchContentDocument(attachedData, loadedDocumentUri,
-                        function (resolvedContentDocumentDom) {
-                            
+                        function(resolvedContentDocumentDom) {
+
                             var uri = iframe.getAttribute("src");
                             iframe.setAttribute("src", "");
-
                             window.URL.revokeObjectURL(uri);
 
                             iframe.onload = function() {
                                 iframe.onload = undefined;
-    
+
                                 callback.call(caller, success, attachedData);
                             };
-                            
-                            var documentDataUri = window.URL.createObjectURL(
-                                new Blob([resolvedContentDocumentDom.documentElement.outerHTML], {'type': 'text/html'})
-                            );
-                            iframe.setAttribute("src", documentDataUri);
-                            
+
+                            var documentHtmlText = [resolvedContentDocumentDom.documentElement.outerHTML];
+
+                            if (window.navigator.userAgent.indexOf("Trident") > 0) {
+                                // Internet Explorer doesn't handle loading documents from Blobs correctly.
+                                // TODO: Currently using the document.write() approach only for IE, as it breaks CSS selectors
+                                // with namespaces for some reason (e.g. the childrens-media-query sample EPUB)
+                                iframe.contentWindow.document.open();
+                                //inject reading system object before writing to the iframe DOM
+                                iframe.contentWindow.navigator.epubReadingSystem = navigator.epubReadingSystem;
+                                iframe.contentWindow.document.write(documentHtmlText);
+                                iframe.contentWindow.document.close();
+                            } else {
+                                var contentDocumentBlob = new Blob(documentHtmlText, {'type': 'application/xhtml+xml'});
+                                var documentDataUri = window.URL.createObjectURL(contentDocumentBlob);
+                                iframe.setAttribute("src", documentDataUri);
+                            }
+
                         }, function (err) {
                             callback.call(caller, success, attachedData);
                         }
@@ -54,10 +73,9 @@ define(['URIjs'], function(URI){
                 };
                 // Feed an artificial empty HTML document to the IFRAME, then let the wrapper onload function
                 // take care of actual document loading (from zipped EPUB) and calling callbacks:
-                var emptyDocumentDataUri = window.URL.createObjectURL(
-                    new Blob(['<html><body></body></html>'], {'type': 'text/html'})
-                );
-
+                var emptyDocumentDataUri = window.URL.createObjectURL(emptyDocumentBlob);
+                // TODO: Need ideas on how to create an IE-supported empty document URI that doesn't use Blobs
+                // and doesn't cause cross origin errors on Chrome (like plain data URLs do).
                 basicIframeLoader.loadIframe(iframe, emptyDocumentDataUri, basicLoadCallback, caller, attachedData);
             } else {
                 basicIframeLoader.loadIframe(iframe, src, callback, caller, attachedData);

--- a/epub-modules/epub-fetch/src/models/resource_cache.js
+++ b/epub-modules/epub-fetch/src/models/resource_cache.js
@@ -19,12 +19,23 @@ define(function () {
             var _resourcesHash = {};
 
             this.getResourceURL = function (resourceAbsoluteHref) {
-                var resourceObjectUrl = _resourcesHash[resourceAbsoluteHref];
+                var resourceObjectUrl = null;
+                var resourceData = _resourcesHash[resourceAbsoluteHref];
+                if (resourceData) {
+                    resourceObjectUrl = resourceData.url;
+                }
                 return resourceObjectUrl;
             };
 
-            this.putResourceURL = function (resourceAbsoluteHref, resourceObjectUrl) {
-                _resourcesHash[resourceAbsoluteHref] = resourceObjectUrl;
+            this.putResourceURL = function (resourceAbsoluteHref, resourceObjectUrl, resourceBlob) {
+                _resourcesHash[resourceAbsoluteHref] = {
+                    url: resourceObjectUrl,
+                    blob: resourceBlob
+                };
+            };
+
+            this.consoleDump = function() {
+                console.log(_resourcesHash);
             };
             // TODO: methods to evict resource, destroy cache and release object URLs using window.URL.revokeObjectURL(), automatic
             // cache size accounting and management algorithms like LRU.


### PR DESCRIPTION
This fixes issue #54.

TODO: Causes problems with CSS selectors that employ namespaces. Need to
find a fix.

Also, many other IE-specific problems exist that prevent documents other from the InDesign demo EPUB to load from a zipped format.
