### PR TITLE
Replace image href in SVG element with blob url

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -268,8 +268,7 @@ define(
             function resolveResourceElements(elemName, refAttr, fetchMode, resolutionDeferreds, onerror,
                                              resourceDataPreprocessing) {
 
-                var resolvedElems = $(elemName + '[' + refAttr + ']', _contentDocumentDom);
-                refAttr = refAttr.replace(/\\/g, '');
+                var resolvedElems = $(elemName + '[' + refAttr.replace(':', '\\:') + ']', _contentDocumentDom);
 
                 resolvedElems.each(function (index, resolvedElem) {
                     var refAttrOrigVal = $(resolvedElem).attr(refAttr);
@@ -286,7 +285,7 @@ define(
 
             function resolveDocumentImages(resolutionDeferreds, onerror) {
                 resolveResourceElements('img', 'src', 'blob', resolutionDeferreds, onerror);
-                resolveResourceElements('image', 'xlink\\:href', 'blob', resolutionDeferreds, onerror);
+                resolveResourceElements('image', 'xlink:href', 'blob', resolutionDeferreds, onerror);
             }
 
             function resolveDocumentAudios(resolutionDeferreds, onerror) {


### PR DESCRIPTION
Resources from zipped epub are processed to work with blob URLs.
Except for SVG images that weren't processed. They are now.
