### PR TITLE
Enable Readium to open File objects directly

### DIFF
--- a/epub-modules/epub-fetch/src/models/publication_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/publication_fetcher.js
@@ -63,9 +63,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
         }
 
         function isExploded() {
-
-            var ext = ".epub";
-            return bookRoot.indexOf(ext, bookRoot.length - ext.length) === -1;
+            return !(bookRoot instanceof File) && !(/\.epub$/.test(bookRoot));
         }
 
         function createResourceFetcher(isExploded, callback) {

--- a/epub-modules/epub-fetch/src/models/publication_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/publication_fetcher.js
@@ -63,7 +63,7 @@ define(['require', 'module', 'jquery', 'URIjs', './markup_parser', './plain_reso
         }
 
         function isExploded() {
-            return !(bookRoot instanceof File) && !(/\.epub$/.test(bookRoot));
+            return !(bookRoot instanceof Blob) && !(/\.epub$/.test(bookRoot));
         }
 
         function createResourceFetcher(isExploded, callback) {

--- a/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
@@ -33,11 +33,19 @@ define(['require', 'module', 'jquery', 'URIjs', './discover_content_type'], func
 
                 zip.workerScriptsPath = libDir;
                 _zipFs = new zip.fs.FS();
-                _zipFs.importHttpContent(baseUrl, true, function () {
 
-                    callback(_zipFs, onerror);
-
-                }, onerror)
+                if(baseUrl instanceof File) {
+                    // baseUrl is the epub File (same as Blob)
+                    _zipFs.importBlob(baseUrl, function () {
+                        callback(_zipFs, onerror);
+                    }, onerror);
+                }
+                else {
+                    // baseUrl is the path to the epub
+                    _zipFs.importHttpContent(baseUrl, true, function () {
+                        callback(_zipFs, onerror);
+                    }, onerror);
+                }
             }
         }
 
@@ -65,7 +73,7 @@ define(['require', 'module', 'jquery', 'URIjs', './discover_content_type'], func
         // PUBLIC API
 
         this.getPackageUrl = function() {
-            return baseUrl;
+            return (baseUrl instanceof File) ? baseUrl.name : baseUrl;
         };
 
         this.fetchFileContentsText = function(relativePathRelativeToPackageRoot, fetchCallback, onerror) {

--- a/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
@@ -37,6 +37,7 @@ define(['require', 'module', 'jquery', 'URIjs', './discover_content_type'], func
                 else {
                     zip.useWebWorkers = false;
                 }
+                _zipFs = new zip.fs.FS();
 
                 if(baseUrl instanceof Blob) {
                     // baseUrl is the epub File (same as Blob)

--- a/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/zip_resource_fetcher.js
@@ -31,10 +31,14 @@ define(['require', 'module', 'jquery', 'URIjs', './discover_content_type'], func
 
             } else {
 
-                zip.workerScriptsPath = libDir;
-                _zipFs = new zip.fs.FS();
+                if(libDir) {
+                    zip.workerScriptsPath = libDir;
+                }
+                else {
+                    zip.useWebWorkers = false;
+                }
 
-                if(baseUrl instanceof File) {
+                if(baseUrl instanceof Blob) {
                     // baseUrl is the epub File (same as Blob)
                     _zipFs.importBlob(baseUrl, function () {
                         callback(_zipFs, onerror);
@@ -73,7 +77,7 @@ define(['require', 'module', 'jquery', 'URIjs', './discover_content_type'], func
         // PUBLIC API
 
         this.getPackageUrl = function() {
-            return (baseUrl instanceof File) ? baseUrl.name : baseUrl;
+            return (baseUrl instanceof Blob) ? ((baseUrl instanceof File) ? baseUrl.name : "readium.epub") : baseUrl;
         };
 
         this.fetchFileContentsText = function(relativePathRelativeToPackageRoot, fetchCallback, onerror) {


### PR DESCRIPTION
Readium can now open a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object ([Blob](https://developer.mozilla.org/fr/docs/Web/API/Blob)) directly.

For example, if you're using the DeviceStorage API, you can read an epub file from the sdcard of a device :

    var sdcard = navigator.getDeviceStorage('sdcard');
    var request = sdcard.get("9782019111281.epub");
    request.onsuccess = function () {
        var file = this.result;
        var readium = new Readium({ jsLibRoot: './libs/' }, { el: '#reader-frame' });
            readium.openPackageDocument(file, function (packageDocument, options) {
                // do whatever you want with your packageDocument...
            });
    };