### PR TITLE
Fix #86 : fill self closing <title> tag with 1 space

### DIFF
--- a/epub-modules/epub-fetch/src/models/content_document_fetcher.js
+++ b/epub-modules/epub-fetch/src/models/content_document_fetcher.js
@@ -58,6 +58,8 @@ define(
                 resolveDocumentLinkStylesheets(resolutionDeferreds, onerror);
                 resolveDocumentEmbeddedStylesheets(resolutionDeferreds, onerror);
 
+                fixSelfClosingTags(resolutionDeferreds);
+
                 $.when.apply($, resolutionDeferreds).done(function () {
                     resolvedDocumentCallback(_contentDocumentDom);
                 });
@@ -322,6 +324,20 @@ define(
                             resolutionDeferred.resolve();
                         });
                 });
+            }
+
+            function fixSelfClosingTags(resolutionDeferreds) {
+                var resolutionDeferred = $.Deferred();
+                resolutionDeferreds.push(resolutionDeferred);
+
+                var resolvedElems = $('title', _contentDocumentDom);
+                resolvedElems.each(function (index, element) {
+                    if (element.textContent === "") {
+                        element.textContent = " ";
+                    }
+                });
+
+                resolutionDeferred.resolve();
             }
 
         };


### PR DESCRIPTION
See #86 

I added a `fixSelfClosingTags` function that fills only the `<title>` tag with one space.
It can be used with other tags as well.
