### PR TITLE
Fix shared-js #148: Wait for custom fonts to load before paginating.

### DIFF
--- a/epub-modules/Readium.js
+++ b/epub-modules/Readium.js
@@ -12,11 +12,13 @@
 //  prior written permission.
 
 
-define(['require', 'text!version.json', 'console_shim', 'jquery', 'underscore', 'readerView', 'epub-fetch', 'epub-model/package_document_parser', 'epub-fetch/iframe_zip_loader', 'URIjs', 'cryptoJs'],
-    function (require, versionText, console_shim, $, _, readerView, PublicationFetcher, PackageParser, IframeZipLoader, URI, cryptoJs) {
+define(['require', 'text!version.json', 'console_shim', 'jquery', 'underscore', 'readerView', 'epub-fetch', 'epub-model/package_document_parser', 'epub-fetch/iframe_zip_loader', 'URIjs', 'cryptoJs', 'FontLoader'],
+    function (require, versionText, console_shim, $, _, readerView, PublicationFetcher, PackageParser, IframeZipLoader, URI, cryptoJs, FontLoader) {
 
     //hack to make URI object global for readers consumption.
     window.URI = URI;
+
+    window.FontLoader = FontLoader;
 
     //polyfill to support Safari 6
     if ('URL' in window === false) {

--- a/rjs_require_config.js
+++ b/rjs_require_config.js
@@ -55,7 +55,8 @@ var requirejs = {
         mediaOvelayDataInjector: 'epub-modules/epub-renderer/src/readium-shared-js/js/views/media_overlay_data_injector',
         internalLinksSupport: 'epub-modules/epub-renderer/src/readium-shared-js/js/views/internal_links_support',
         iframeLoader: 'epub-modules/epub-renderer/src/readium-shared-js/js/views/iframe_loader',
-        
+        fontLoader: 'epub-modules/epub-renderer/src/readium-shared-js/js/views/font_loader',
+
 
         domReady : 'lib/domReady',
         cryptoJs: 'lib/2.5.3-crypto-sha1',
@@ -66,6 +67,7 @@ var requirejs = {
         "rangy-highlighter" : 'epub-modules/epub-renderer/src/readium-shared-js/lib/rangy/rangy-highlighter',
         "rangy-cssclassapplier" : 'epub-modules/epub-renderer/src/readium-shared-js/lib/rangy/rangy-cssclassapplier',
         "rangy-position" : 'epub-modules/epub-renderer/src/readium-shared-js/lib/rangy/rangy-position',
+        FontLoader: 'epub-modules/epub-renderer/src/readium-shared-js/lib/FontLoader',
         
         Readium: 'epub-modules/Readium'
     },
@@ -305,7 +307,7 @@ var requirejs = {
         readerView : {
             deps: [ 'backbone','readiumSDK', 'helpers', 'viewerSettings', 'styleCollection', 'package',
                 'mediaOverlayPlayer', 'pageOpenRequest', 'fixedView', 'reflowableView', 'mediaOvelayDataInjector',
-                'internalLinksSupport', 'iframeLoader', 'annotationsManager', 'scrollView', 'URIjs', 'triggers', 'switches'],
+                'internalLinksSupport', 'iframeLoader', 'annotationsManager', 'scrollView', 'URIjs', 'triggers', 'switches', 'fontLoader'],
             exports:'readerView'
         },
 


### PR DESCRIPTION
This adds the library in require-js config needed for PR https://github.com/readium/readium-shared-js/pull/179