### PR TITLE
Add case for Edge in 'IE' detection

### DIFF
--- a/js/epub-fetch/iframe_zip_loader.js
+++ b/js/epub-fetch/iframe_zip_loader.js
@@ -15,7 +15,7 @@ define(['URIjs', 'readium_shared_js/views/iframe_loader', 'underscore', './disco
 
     var zipIframeLoader = function( getCurrentResourceFetcher, contentDocumentTextPreprocessor) {
 
-        var isIE = (window.navigator.userAgent.indexOf("Trident") > 0);
+        var isIE = (window.navigator.userAgent.indexOf("Trident") > 0 || window.navigator.userAgent.indexOf("Edge") > 0);
             
         var basicIframeLoader = new IFrameLoader();
 


### PR DESCRIPTION
Should fix [Issue 112](https://github.com/readium/readium-js/issues/112)

Or observations so far are that loading `contentDocumentData` from a blob (still) doesn't appear to work and this is an example of an Edge user agent:
> Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240