### PR TITLE
Improve MathML detection

### DIFF
--- a/js/Readium.js
+++ b/js/Readium.js
@@ -41,7 +41,7 @@ define(['text!version.json', 'jquery', 'underscore', 'readium_shared_js/views/re
 
             var scripts = "<script type=\"text/javascript\">(" + injectedScript.toString() + ")()<\/script>";
 
-            if (_options && _options.mathJaxUrl && contentDocumentHtml.indexOf("<math") >= 0) {
+            if (_options && _options.mathJaxUrl && contentDocumentHtml.search(/<(.*)(?=math)/) >= 0) {
                 scripts += "<script type=\"text/javascript\" src=\"" + _options.mathJaxUrl + "\"> <\/script>";
             }
 

--- a/js/Readium.js
+++ b/js/Readium.js
@@ -41,7 +41,7 @@ define(['text!version.json', 'jquery', 'underscore', 'readium_shared_js/views/re
 
             var scripts = "<script type=\"text/javascript\">(" + injectedScript.toString() + ")()<\/script>";
 
-            if (_options && _options.mathJaxUrl && contentDocumentHtml.search(/<(.*)(?=math)/) >= 0) {
+            if (_options && _options.mathJaxUrl && contentDocumentHtml.search(/<(\w+:|)(?=math>)/) >= 0) {
                 scripts += "<script type=\"text/javascript\" src=\"" + _options.mathJaxUrl + "\"> <\/script>";
             }
 

--- a/js/Readium.js
+++ b/js/Readium.js
@@ -41,7 +41,7 @@ define(['text!version.json', 'jquery', 'underscore', 'readium_shared_js/views/re
 
             var scripts = "<script type=\"text/javascript\">(" + injectedScript.toString() + ")()<\/script>";
 
-            if (_options && _options.mathJaxUrl && contentDocumentHtml.search(/<(\w+:|)(?=math>)/) >= 0) {
+            if (_options && _options.mathJaxUrl && contentDocumentHtml.search(/<(\w+:|)(?=math)/) >= 0) {
                 scripts += "<script type=\"text/javascript\" src=\"" + _options.mathJaxUrl + "\"> <\/script>";
             }
 


### PR DESCRIPTION
We found cases (for instance when MathML markup is ns-prefixed: `<m:math><m:mrow><m:mrow><m:mfrac><m:mrow><m:mn>3</m:mn></m:mrow><m:mrow><m:mn>5</m:mn></m:mrow></m:mfrac></m:mrow></m:mrow></m:math>`) where MathML present but was not being detected.

This should provide an improved scan of the document.