### PR TITLE
FIX - Cordova File does not inherit from Blob.

### DIFF
--- a/js/Readium.js
+++ b/js/Readium.js
@@ -126,6 +126,7 @@ define(['text!version.json', 'jquery', 'underscore', 'readium_shared_js/views/re
         this.openPackageDocument = function(ebookURL, callback, openPageRequest)  {
                         
             if (!(ebookURL instanceof Blob)
+                && !(ebookURL instanceof File)
                 // && ebookURL.indexOf("file://") != 0
                 // && ebookURL.indexOf("filesystem://") != 0
                 // && ebookURL.indexOf("filesystem:chrome-extension://") != 0

--- a/js/epub-fetch/publication_fetcher.js
+++ b/js/epub-fetch/publication_fetcher.js
@@ -64,8 +64,8 @@ define(['jquery', 'URIjs', './markup_parser', './plain_resource_fetcher', './zip
 
         function isExploded() {
             // binary object means packed EPUB
-            if (ebookURL instanceof Blob) return false;
-            
+            if (ebookURL instanceof Blob || ebookURL instanceof File) return false;
+
             if (_contentType &&
                 (
                     _contentType.indexOf("application/epub+zip") >= 0

--- a/js/epub-fetch/zip_resource_fetcher.js
+++ b/js/epub-fetch/zip_resource_fetcher.js
@@ -52,9 +52,9 @@ define(['jquery', 'URIjs', './discover_content_type', 'zip-ext', 'readium_shared
                 }
 
                 _zipFs = new zip.fs.FS();
-                
-                if (ebookURL instanceof Blob) {
-                    
+
+                if (ebookURL instanceof Blob || ebookURL instanceof File) {
+
                     _zipFs.importBlob(
                         ebookURL,
                         function () {  
@@ -120,7 +120,7 @@ define(['jquery', 'URIjs', './discover_content_type', 'zip-ext', 'readium_shared
                     var isReadiumError = error ? (error.message.indexOf(READIUM_ERROR_PREFIX) == 0) : false;
                     
                     // we fallback to Blobl for all other types of errors (not just those emanating from the zip lib, but also from the readCallback())
-                    if (!isReadiumError && !(ebookURL instanceof Blob)) {
+                    if (!isReadiumError && !(ebookURL instanceof Blob) && !(ebookURL instanceof File)) {
                         console.log("Zip lib failed to load zipped EPUB via HTTP, trying alternative HTTP fetch... (" + ebookURL + ")");
                         
                         var xhr = new XMLHttpRequest();
@@ -139,8 +139,8 @@ define(['jquery', 'URIjs', './discover_content_type', 'zip-ext', 'readium_shared
                                 //console.log(ebookURL_filepath);
                                 
                                 _zipFs = undefined;
-                                
-                                if (ebookURL instanceof Blob) {
+
+                                if (ebookURL instanceof Blob || ebookURL instanceof File) {
                                     fetchFileContents(relativePathRelativeToPackageRoot, readCallback, onerror);
                                 }
                                 else {


### PR DESCRIPTION
* File and Blob must be checked in order to use a local EPUB in a Cordova app.
* readium-shared-js contains a final piece of the fix.