### PR TITLE
XML to HTML tag fix.

### DIFF
--- a/js/Readium.js
+++ b/js/Readium.js
@@ -64,6 +64,39 @@ define(['readium_shared_js/globals', 'text!version.json', 'jquery', 'underscore'
             contentDocumentHtml = contentDocumentHtml.replace(/<title>[\s]*<\/title>/g, '<title>TITLE</title>');
             contentDocumentHtml = contentDocumentHtml.replace(/<title[\s]*\/>/g, '<title>TITLE</title>');
             
+            // When using the IE iframe loader all documents are loaded as html. EPUBs are valid XML so self closing
+            // XML tags must be converted to html in order to not break the browser.
+            var validSelfClosingTags = [
+                'area',
+                'base',
+                'br',
+                'col',
+                'command',
+                'embed',
+                'hr',
+                'img',
+                'input',
+                'keygen',
+                'link',
+                'meta',
+                'param',
+                'source',
+                'track',
+                'wbr'
+            ];
+
+            var replacementFunc = function (tag) {
+                var tokens = tag.match(/<(.*)\/>/i)[1].split(' ');
+                var tagName = tokens[0];
+                if (validSelfClosingTags.indexOf(tagName) === -1) {
+                    return '<' + tokens.join(' ') + '>' + '</' + tokens[0] + '>';
+                } else {
+                    return tag;
+                }
+            };
+
+            contentDocumentHtml =  contentDocumentHtml.replace(/<[\s]*[\S][\s]*[^>]*\/>/gi, replacementFunc);
+            
             return contentDocumentHtml;
         };
 


### PR DESCRIPTION
* The method used to load the spine items into iframes for IE does not (cannot?) maintain the content type. All documents end up being treated as HTML. This breaks EPUBs (in particular the CFI generation) that leverage XML since many self closed tags are invalid in HTML.

* The 'fix'/hack for now is to parse the spine item and replace invalid self closing tags with html valid closing tags.

* After a slack discussion it was decided to do this for all browsers to maintain consistency.