### PR TITLE
Fix for IE10 Quote/Apostrophe

### DIFF
--- a/js/Readium.js
+++ b/js/Readium.js
@@ -64,6 +64,12 @@ define(['readium_shared_js/globals', 'text!version.json', 'jquery', 'underscore'
             contentDocumentHtml = contentDocumentHtml.replace(/<title>[\s]*<\/title>/g, '<title>TITLE</title>');
             contentDocumentHtml = contentDocumentHtml.replace(/<title[\s]*\/>/g, '<title>TITLE</title>');
             
+            // Replace quotes < IE 10 cannot handle proper quoting when traversting textNodes.
+            contentDocumentHtml = contentDocumentHtml.replace(/(“)/g, '"'); // &#8220;
+            contentDocumentHtml = contentDocumentHtml.replace(/(”)/g, '"'); // &#8221;
+            // Replace apostrophes
+            contentDocumentHtml = contentDocumentHtml.replace(/(’)/g, '\''); // &#8217;
+            
             return contentDocumentHtml;
         };
 


### PR DESCRIPTION
* In books with proper quotes and apostrophes IE will cut off the text node at the character. This breaks loading CFIs with text offsets. The fix was to change proper quotes/apostrohpes to ' and ".