### PR TITLE
Rdh resource fetcher plugin

### DIFF
--- a/js/Readium.js
+++ b/js/Readium.js
@@ -142,7 +142,13 @@ define(['readium_shared_js/globals', 'text!version.json', 'jquery', 'underscore'
 
 
         this.openPackageDocument = function(ebookURL, callback, openPageRequest)  {
-                        
+            var resourcePluginKey='ResourceFetcherPlugin';
+            var plugins = ReadiumSDK.Plugins.getLoadedPlugins()
+            if (_.has(plugins, resourcePluginKey)) {
+                _resourceFetcher = plugins[resourcePluginKey].CustomResourceFetcher.openPackageDocument(ebookURL, callback, openPageRequest, openPackageDocument_)
+                return;
+            }
+
             if (!(ebookURL instanceof Blob)
                 && !(ebookURL instanceof File)
                 // && ebookURL.indexOf("file://") != 0


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
See also #144*

#### Test cases, sample files

### Additional information
This code allows for a resource fetcher plugin.  If one is specified, then it is used in place of the built-in resource fetchers.

The Bibliotheca hybrid app uses this to load a resource fetcher that gets content from an API.

Some thoughts on this code:
1) in publication_fetcher.js, about line 137, the code is slightly different between the base code and this code; specifically I removed isExploded().  I'm not sure if that is a breaking change for users that don't have a plugin.
2) It would be nice to move the existing resource fetchers to plugins as well.

3) I don't know how to clear up the "readium_shared_js" issue that I see at the bottom of this pull request.
