### PR TITLE
Rdh resource fetcher events

### DIFF
--- a/js/epub-fetch/content_document_fetcher.js
+++ b/js/epub-fetch/content_document_fetcher.js
@@ -37,7 +37,9 @@ define(
                         if (_contentDocumentTextPreprocessor) {
                             _contentDocumentText = _contentDocumentTextPreprocessor(loadedDocumentUri, _contentDocumentText);
                         }
+                        ReadiumSDK.emit('ContentDocumentFetcher-BeforeResolveResources');
                         self.resolveInternalPackageResources(contentDocumentResolvedCallback, errorCallback);
+                        ReadiumSDK.emit('ContentDocumentFetcher-AfterResolveResources');
                     }, errorCallback
                 );
             };
@@ -52,7 +54,7 @@ define(
                 if (_publicationFetcher.shouldFetchMediaAssetsProgrammatically()) {
                     
                     console.log("fetchMediaAssetsProgrammatically ...");
-            
+
                     resolveDocumentImages(resolutionDeferreds, onerror);
                     
                     resolveDocumentAudios(resolutionDeferreds, onerror);
@@ -60,7 +62,7 @@ define(
                     
                     // both audio and video
                     resolveResourceElements('source', 'src', 'blob', resolutionDeferreds, onerror);
-                    
+
                     resolveResourceElements('object', 'data', 'blob', resolutionDeferreds, onerror);
                 }
 
@@ -262,6 +264,8 @@ define(
 
             function preprocessCssStyleSheetData(styleSheetResourceData, styleSheetUriRelativeToPackageDocument,
                                                  callback) {
+                ReadiumSDK.emit('ContentDocumentFetcher-BeforeResolveResources');
+
                 var cssUrlRegexp = /[Uu][Rr][Ll]\(\s*([']([^']+)[']|["]([^"]+)["]|([^)]+))\s*\)/g;
                 var nonUrlCssImportRegexp = /@[Ii][Mm][Pp][Oo][Rr][Tt]\s*('([^']+)'|"([^"]+)")/g;
                 var stylesheetCssResourceUrlsMap = {};
@@ -286,6 +290,7 @@ define(
                     }
 
                 });
+                ReadiumSDK.emit('ContentDocumentFetcher-AfterResolveResources');
 
                 if (cssResourceDownloadDeferreds.length > 0) {
                     $.when.apply($, cssResourceDownloadDeferreds).done(function () {


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
See also #144*

#### Test cases, sample files

### Additional information
Provides additional events to be emitted when resource fetcher is getting internal resources (files listed in the HTML of the chapter) and for files embedded in the css file(s).

The Bibliotheca hybrid app uses this to help it's resource fetcher plugin batch up file requests.  Essentially, when the start event is emitted, it begins a batch; then individual file requests are queued up.   When the end event is emitted, it sends the queued up list of files to the API, which reads the contents of each specified file and returns the contents as a response.

This helps to make the resource fetcher more performant because it limits the number of requests sent across the wire.
