### PR TITLE
Fix incorrect dom tree produced in IE11 when source has self-closed tags

### DIFF
--- a/js/epub-fetch/iframe_zip_loader.js
+++ b/js/epub-fetch/iframe_zip_loader.js
@@ -112,6 +112,11 @@ define(['URIjs', 'readium_shared_js/views/iframe_loader', 'underscore', './disco
                 // Internet Explorer doesn't handle loading documents from Blobs correctly.
                 // TODO: Currently using the document.write() approach only for IE, as it breaks CSS selectors
                 // with namespaces for some reason (e.g. the childrens-media-query sample EPUB)
+
+                // fix self-closed tags in the contentDocumentData; otherwise IE (IE11) creates an incorrect DOM tree
+                contentDocumentData=contentDocumentData.replace(/<([a-z]+)([^>]+)?\/>/g,'<$1$2></$1>')
+
+
                 iframe.contentWindow.document.open();
 
                 // Currently not handled automatically by winstore-jscompat,


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)

#### Test cases, sample files

### Additional information
Because of the way that the document is loaded into the iframe for IE, self-closing tags can lead to an incorrect DOM tree.  This code replaces self-closed tags with non-self-closing tags, which eliminates the problem.


