### PR TITLE
Change "zipjs" -> "zip-js" to match name field

### DIFF
--- a/package.cson
+++ b/package.cson
@@ -112,7 +112,7 @@ devDependencies:
 
 #    "zipjs": 'gildas-lormeau/zip.js'
 #    "zipjs": 'ryanackley/zip.js'
-    "zipjs": "danielweck/zip.js"
+    "zip-js": "danielweck/zip.js"
 
 # see readium-cfi-js:
 # "requirejs", "almond", "jquery"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "crypto-js": "latest",
-    "zipjs": "danielweck/zip.js",
+    "zip-js": "danielweck/zip.js",
     "requirejs-text": "latest",
     "gift": "latest"
   },


### PR DESCRIPTION
Fix module name in `package.json`: "zipjs" -> "zip-js" 

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)

#165

#### Test cases, sample files

### Additional information

